### PR TITLE
Add SwiftUI skeleton for Webtoon Manager app

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ A simple SwiftUI app skeleton for managing webtoons.
 
 ## Building
 Create a new iOS App project in Xcode (iOS 17 or later) and replace the template's source files with the contents of the `WebtoonManager` folder. Then build the `WebtoonManagerApp` target.
+Copy `WebtoonManager/Info.plist` into your project or make sure your own Info.plist includes `NSPhotoLibraryUsageDescription`, `NSPhotoLibraryAddUsageDescription`, and `NSAppTransportSecurity` with `NSAllowsArbitraryLoads` so the app can access the photo library and fetch web data.
 
 ## Features
 - Four tabs: Home, Search, Add Webtoon, Settings.
 - Search results lead to a detail view with a progress bar for reading status.
 - Basic data model for storing webtoon info including thumbnail URL.
 - Automatic API updates can run while the app is open when enabled in Settings.
-- Home page displays your own `AppLogo` image scaled to about 390pt width (use a 2048×2048 square asset named `AppLogo`).
+- Home page displays your own `AppLogo` image scaled to about 390pt width (add a square asset named `AppLogo`, recommended size 886×886 at 132 DPI).
 - App remembers the last selected tab and saved webtoons across launches.
 - Edit or delete saved webtoons in the Search tab via swipe actions. Sorting options include rating, title or most recent click.
 - Add multiple writers and genres, numeric episode fields and local image selection when creating or editing webtoons.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Create a new iOS App project in Xcode (iOS 17 or later) and replace the template
 - Edit or delete saved webtoons in the Search tab via swipe actions. Sorting options include rating, title or most recent click.
 - Add multiple writers and genres, numeric episode fields and local image selection when creating or editing webtoons.
 - Manage global writer, studio and genre lists under Settings → 카테고리 관리.
+- The first launch requests photo library permission and asks whether to allow
+  network access for automatic updates.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Create a new iOS App project in Xcode (iOS 17 or later) and replace the template
 - Four tabs: Home, Search, Add Webtoon, Settings.
 - Search results lead to a detail view with a progress bar for reading status.
 - Basic data model for storing webtoon info including thumbnail URL.
-- Placeholder automatic API update toggle in Settings.
-- Home page displays a custom `AppLogo` image scaled to fit the screen width (about 390pt on iPhone 14 Pro). Any square image asset named `AppLogo` will work.
+- Automatic API updates can run while the app is open when enabled in Settings.
+- Home page displays your own `AppLogo` image scaled to about 390pt width (use a 2048×2048 square asset named `AppLogo`).
 - App remembers the last selected tab and saved webtoons across launches.
 - Edit or delete saved webtoons in the Search tab via swipe actions. Sorting options include rating, title or most recent click.
 - Add multiple writers and genres, numeric episode fields and local image selection when creating or editing webtoons.
 - Manage global writer, studio and genre lists under Settings → 카테고리 관리.
+- Choose between light, dark, sepia or poster themes in Settings; the selection applies immediately.
 - Saved categories, writers and studios can be removed using the - button while editing the list.
 - The first launch requests photo library permission and asks whether to allow
   network access for automatic updates.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# ihatecodex
+# WebtoonManager
+
+A simple SwiftUI app skeleton for managing webtoons.
+
+## Building
+Open `WebtoonManager` directory in Xcode (on macOS) and build the `WebtoonManagerApp` target.
+
+## Features
+- Four tabs: Home, Search, Add Webtoon, Settings.
+- Basic data model for storing webtoon info.
+- Placeholder automatic API update toggle in Settings.
+- Home page displays `AppLogo` image scaled to 390pt width. Add your own 2048x2048 image named `AppLogo` in Assets.xcassets.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 A simple SwiftUI app skeleton for managing webtoons.
 
 ## Building
-Open `WebtoonManager` directory in Xcode (on macOS) and build the `WebtoonManagerApp` target.
+Create a new iOS App project in Xcode (iOS 17 or later) and replace the template's source files with the contents of the `WebtoonManager` folder. Then build the `WebtoonManagerApp` target.
 
 ## Features
 - Four tabs: Home, Search, Add Webtoon, Settings.
-- Basic data model for storing webtoon info.
+- Search results lead to a detail view with a progress bar for reading status.
+- Basic data model for storing webtoon info including thumbnail URL.
 - Placeholder automatic API update toggle in Settings.
 - Home page displays `AppLogo` image scaled to 390pt width. Add your own 2048x2048 image named `AppLogo` in Assets.xcassets.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Create a new iOS App project in Xcode (iOS 17 or later) and replace the template
 - Basic data model for storing webtoon info including thumbnail URL.
 - Placeholder automatic API update toggle in Settings.
 - Home page displays `AppLogo` image scaled to 390pt width. Add your own 2048x2048 image named `AppLogo` in Assets.xcassets.
+- App remembers the last selected tab and saved webtoons across launches.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple SwiftUI app skeleton for managing webtoons.
 
 ## Building
 Create a new iOS App project in Xcode (iOS 17 or later) and replace the template's source files with the contents of the `WebtoonManager` folder. Then build the `WebtoonManagerApp` target.
-Copy `WebtoonManager/Info.plist` into your project or make sure your own Info.plist includes `NSPhotoLibraryUsageDescription`, `NSPhotoLibraryAddUsageDescription`, and `NSAppTransportSecurity` with `NSAllowsArbitraryLoads` so the app can access the photo library and fetch web data.
+Copy `WebtoonManager/Info.plist` into your project or make sure your own Info.plist includes `NSPhotoLibraryUsageDescription`, `NSPhotoLibraryAddUsageDescription`, and `NSAppTransportSecurity` with `NSAllowsArbitraryLoads` so the app can access the photo library and fetch web data. If you import this plist file, replace the default one referenced by your target's **Info.plist File** setting and remove any duplicate entry from *Copy Bundle Resources* to avoid build errors about multiple Info.plist files.
 
 ## Features
 - Four tabs: Home, Search, Add Webtoon, Settings.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Create a new iOS App project in Xcode (iOS 17 or later) and replace the template
 - Search results lead to a detail view with a progress bar for reading status.
 - Basic data model for storing webtoon info including thumbnail URL.
 - Placeholder automatic API update toggle in Settings.
-- Home page displays `AppLogo` image scaled to 390pt width. Add your own 2048x2048 image named `AppLogo` in Assets.xcassets.
+- Home page displays `AppLogo` image scaled to 390pt width. Add your own 886x886 image (132×132 DPI) named `AppLogo` in Assets.xcassets.
 - App remembers the last selected tab and saved webtoons across launches.
-- Edit or delete saved webtoons in the Search tab via swipe actions.
+- Edit or delete saved webtoons in the Search tab via swipe actions. Sorting options include rating, title or most recent click.
 - Add multiple writers and categories, numeric episode fields and local image selection when creating or editing webtoons.
 - Manage global writer, studio and category lists under Settings → 카테고리 관리.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Create a new iOS App project in Xcode (iOS 17 or later) and replace the template
 - Search results lead to a detail view with a progress bar for reading status.
 - Basic data model for storing webtoon info including thumbnail URL.
 - Placeholder automatic API update toggle in Settings.
-- Home page displays `AppLogo` image scaled to 390pt width. Add your own 886x886 image (132×132 DPI) named `AppLogo` in Assets.xcassets.
+- Home page displays `AppLogo` image scaled to 390pt width. Add your own 2048x2048 image named `AppLogo` in Assets.xcassets.
 - App remembers the last selected tab and saved webtoons across launches.
 - Edit or delete saved webtoons in the Search tab via swipe actions. Sorting options include rating, title or most recent click.
-- Add multiple writers and categories, numeric episode fields and local image selection when creating or editing webtoons.
-- Manage global writer, studio and category lists under Settings → 카테고리 관리.
+- Add multiple writers and genres, numeric episode fields and local image selection when creating or editing webtoons.
+- Manage global writer, studio and genre lists under Settings → 카테고리 관리.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Create a new iOS App project in Xcode (iOS 17 or later) and replace the template
 - Search results lead to a detail view with a progress bar for reading status.
 - Basic data model for storing webtoon info including thumbnail URL.
 - Placeholder automatic API update toggle in Settings.
-- Home page displays `AppLogo` image scaled to 390pt width. Add your own 2048x2048 image named `AppLogo` in Assets.xcassets.
+- Home page displays a custom `AppLogo` image scaled to fit the screen width (about 390pt on iPhone 14 Pro). Any square image asset named `AppLogo` will work.
 - App remembers the last selected tab and saved webtoons across launches.
 - Edit or delete saved webtoons in the Search tab via swipe actions. Sorting options include rating, title or most recent click.
 - Add multiple writers and genres, numeric episode fields and local image selection when creating or editing webtoons.
 - Manage global writer, studio and genre lists under Settings → 카테고리 관리.
+- Saved categories, writers and studios can be removed using the - button while editing the list.
 - The first launch requests photo library permission and asks whether to allow
   network access for automatic updates.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ Create a new iOS App project in Xcode (iOS 17 or later) and replace the template
 - Placeholder automatic API update toggle in Settings.
 - Home page displays `AppLogo` image scaled to 390pt width. Add your own 2048x2048 image named `AppLogo` in Assets.xcassets.
 - App remembers the last selected tab and saved webtoons across launches.
+- Edit or delete saved webtoons in the Search tab via swipe actions.
+- Add multiple writers and categories, numeric episode fields and local image selection when creating or editing webtoons.
+- Manage global writer, studio and category lists under Settings → 카테고리 관리.

--- a/WebtoonManager/Info.plist
+++ b/WebtoonManager/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.WebtoonManager</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>썸네일 이미지를 선택하기 위해 사진 라이브러리 접근이 필요합니다.</string>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>썸네일 이미지를 저장하기 위해 사진 라이브러리 접근이 필요합니다.</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/WebtoonManager/Models/Webtoon.swift
+++ b/WebtoonManager/Models/Webtoon.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum WebtoonStatus: String, CaseIterable, Identifiable, Codable {
+    case ongoing = "연재 중"
+    case completed = "완결"
+    case hiatus = "휴재"
+
+    var id: String { rawValue }
+}
+
+enum WebtoonRating: String, CaseIterable, Identifiable, Codable {
+    case poor = "졸작"
+    case average = "보통"
+    case good = "수작"
+    case great = "명작"
+
+    var id: String { rawValue }
+}
+
+struct Webtoon: Identifiable, Codable {
+    let id: UUID
+    var title: String
+    var writer: String
+    var studio: String
+    var category: String
+    var status: WebtoonStatus
+    var rating: WebtoonRating
+    var episodes: Int
+    var lastRead: Int
+    var review: String
+}

--- a/WebtoonManager/Models/Webtoon.swift
+++ b/WebtoonManager/Models/Webtoon.swift
@@ -20,13 +20,14 @@ enum WebtoonRating: String, CaseIterable, Identifiable, Codable {
 struct Webtoon: Identifiable, Codable, Equatable {
     var id: UUID = UUID()
     var title: String
-    var writer: String
+    var writers: [String]
     var studio: String
-    var category: String
+    var categories: [String]
     var status: WebtoonStatus
     var rating: WebtoonRating
     var episodes: Int
     var lastRead: Int
     var review: String
     var thumbnailURL: String
+    var thumbnailData: Data?
 }

--- a/WebtoonManager/Models/Webtoon.swift
+++ b/WebtoonManager/Models/Webtoon.swift
@@ -30,4 +30,63 @@ struct Webtoon: Identifiable, Codable, Equatable {
     var review: String
     var thumbnailURL: String
     var thumbnailData: Data?
+    var savedAt: Date = Date()
+    var lastAccess: Date = Date()
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, writers, studio, categories, status, rating, episodes, lastRead, review, thumbnailURL, thumbnailData, savedAt, lastAccess
+    }
+
+    init(id: UUID = UUID(), title: String, writers: [String], studio: String, categories: [String], status: WebtoonStatus, rating: WebtoonRating, episodes: Int, lastRead: Int, review: String, thumbnailURL: String, thumbnailData: Data?, savedAt: Date = Date(), lastAccess: Date = Date()) {
+        self.id = id
+        self.title = title
+        self.writers = writers
+        self.studio = studio
+        self.categories = categories
+        self.status = status
+        self.rating = rating
+        self.episodes = episodes
+        self.lastRead = lastRead
+        self.review = review
+        self.thumbnailURL = thumbnailURL
+        self.thumbnailData = thumbnailData
+        self.savedAt = savedAt
+        self.lastAccess = lastAccess
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        title = try container.decode(String.self, forKey: .title)
+        writers = try container.decode([String].self, forKey: .writers)
+        studio = try container.decode(String.self, forKey: .studio)
+        categories = try container.decode([String].self, forKey: .categories)
+        status = try container.decode(WebtoonStatus.self, forKey: .status)
+        rating = try container.decode(WebtoonRating.self, forKey: .rating)
+        episodes = try container.decode(Int.self, forKey: .episodes)
+        lastRead = try container.decode(Int.self, forKey: .lastRead)
+        review = try container.decode(String.self, forKey: .review)
+        thumbnailURL = try container.decode(String.self, forKey: .thumbnailURL)
+        thumbnailData = try container.decodeIfPresent(Data.self, forKey: .thumbnailData)
+        savedAt = try container.decodeIfPresent(Date.self, forKey: .savedAt) ?? Date()
+        lastAccess = try container.decodeIfPresent(Date.self, forKey: .lastAccess) ?? savedAt
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encode(writers, forKey: .writers)
+        try container.encode(studio, forKey: .studio)
+        try container.encode(categories, forKey: .categories)
+        try container.encode(status, forKey: .status)
+        try container.encode(rating, forKey: .rating)
+        try container.encode(episodes, forKey: .episodes)
+        try container.encode(lastRead, forKey: .lastRead)
+        try container.encode(review, forKey: .review)
+        try container.encode(thumbnailURL, forKey: .thumbnailURL)
+        try container.encodeIfPresent(thumbnailData, forKey: .thumbnailData)
+        try container.encode(savedAt, forKey: .savedAt)
+        try container.encode(lastAccess, forKey: .lastAccess)
+    }
 }

--- a/WebtoonManager/Models/Webtoon.swift
+++ b/WebtoonManager/Models/Webtoon.swift
@@ -17,8 +17,8 @@ enum WebtoonRating: String, CaseIterable, Identifiable, Codable {
     var id: String { rawValue }
 }
 
-struct Webtoon: Identifiable, Codable {
-    let id: UUID
+struct Webtoon: Identifiable, Codable, Equatable {
+    var id: UUID = UUID()
     var title: String
     var writer: String
     var studio: String
@@ -28,4 +28,5 @@ struct Webtoon: Identifiable, Codable {
     var episodes: Int
     var lastRead: Int
     var review: String
+    var thumbnailURL: String
 }

--- a/WebtoonManager/ViewModels/WebtoonStore.swift
+++ b/WebtoonManager/ViewModels/WebtoonStore.swift
@@ -8,6 +8,9 @@ class WebtoonStore: ObservableObject {
     @Published var autoUpdate: Bool = true {
         didSet { save(); startAutoUpdate() }
     }
+    @Published var categories: [String] = [] { didSet { save() } }
+    @Published var writers: [String] = [] { didSet { save() } }
+    @Published var studios: [String] = [] { didSet { save() } }
 
     private var timer: Timer?
     private let saveURL: URL = {
@@ -18,6 +21,9 @@ class WebtoonStore: ObservableObject {
     private struct SavedData: Codable {
         var webtoons: [Webtoon]
         var autoUpdate: Bool
+        var categories: [String]
+        var writers: [String]
+        var studios: [String]
     }
 
     init() {
@@ -27,11 +33,13 @@ class WebtoonStore: ObservableObject {
 
     func add(_ webtoon: Webtoon) {
         webtoons.append(webtoon)
+        insertLists(from: webtoon)
     }
 
     func update(_ webtoon: Webtoon) {
         guard let index = webtoons.firstIndex(where: { $0.id == webtoon.id }) else { return }
         webtoons[index] = webtoon
+        insertLists(from: webtoon)
     }
 
     func startAutoUpdate() {
@@ -53,15 +61,88 @@ class WebtoonStore: ObservableObject {
         startAutoUpdate()
     }
 
+    func renameCategory(at index: Int, new: String) {
+        let old = categories[index]
+        categories[index] = new
+        for i in webtoons.indices {
+            webtoons[i].categories = webtoons[i].categories.map { $0 == old ? new : $0 }
+        }
+    }
+
+    func deleteCategory(at offsets: IndexSet) {
+        for i in offsets {
+            let removed = categories[i]
+            categories.remove(at: i)
+            for j in webtoons.indices {
+                webtoons[j].categories.removeAll { $0 == removed }
+            }
+        }
+    }
+
+    func renameWriter(at index: Int, new: String) {
+        let old = writers[index]
+        writers[index] = new
+        for i in webtoons.indices {
+            webtoons[i].writers = webtoons[i].writers.map { $0 == old ? new : $0 }
+        }
+    }
+
+    func deleteWriter(at offsets: IndexSet) {
+        for i in offsets {
+            let removed = writers[i]
+            writers.remove(at: i)
+            for j in webtoons.indices {
+                webtoons[j].writers.removeAll { $0 == removed }
+            }
+        }
+    }
+
+    func renameStudio(at index: Int, new: String) {
+        let old = studios[index]
+        studios[index] = new
+        for i in webtoons.indices {
+            if webtoons[i].studio == old {
+                webtoons[i].studio = new
+            }
+        }
+    }
+
+    func deleteStudio(at offsets: IndexSet) {
+        for i in offsets {
+            let removed = studios[i]
+            studios.remove(at: i)
+            for j in webtoons.indices {
+                if webtoons[j].studio == removed {
+                    webtoons[j].studio = ""
+                }
+            }
+        }
+    }
+
+    private func insertLists(from webtoon: Webtoon) {
+        for c in webtoon.categories where !categories.contains(c) {
+            categories.append(c)
+        }
+        for w in webtoon.writers where !writers.contains(w) {
+            writers.append(w)
+        }
+        if !webtoon.studio.isEmpty && !studios.contains(webtoon.studio) {
+            studios.append(webtoon.studio)
+        }
+    }
+
     private func load() {
         guard let data = try? Data(contentsOf: saveURL),
               let saved = try? JSONDecoder().decode(SavedData.self, from: data) else { return }
         webtoons = saved.webtoons
         autoUpdate = saved.autoUpdate
+        categories = saved.categories
+        writers = saved.writers
+        studios = saved.studios
     }
 
     private func save() {
-        let saved = SavedData(webtoons: webtoons, autoUpdate: autoUpdate)
+        let saved = SavedData(webtoons: webtoons, autoUpdate: autoUpdate, categories: categories, writers: writers, studios: studios)
         if let data = try? JSONEncoder().encode(saved) {
             try? data.write(to: saveURL)
         }

--- a/WebtoonManager/ViewModels/WebtoonStore.swift
+++ b/WebtoonManager/ViewModels/WebtoonStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import SwiftUI
 
 class WebtoonStore: ObservableObject {
     @Published var webtoons: [Webtoon] = [] {
@@ -11,6 +12,7 @@ class WebtoonStore: ObservableObject {
     @Published var categories: [String] = [] { didSet { save() } }
     @Published var writers: [String] = [] { didSet { save() } }
     @Published var studios: [String] = [] { didSet { save() } }
+    @Published var theme: String = "system" { didSet { save() } }
 
     private var timer: Timer?
     private let saveURL: URL = {
@@ -24,6 +26,7 @@ class WebtoonStore: ObservableObject {
         var categories: [String]
         var writers: [String]
         var studios: [String]
+        var theme: String
     }
 
     init() {
@@ -147,12 +150,39 @@ class WebtoonStore: ObservableObject {
         categories = saved.categories
         writers = saved.writers
         studios = saved.studios
+        theme = saved.theme
     }
 
     private func save() {
-        let saved = SavedData(webtoons: webtoons, autoUpdate: autoUpdate, categories: categories, writers: writers, studios: studios)
+        let saved = SavedData(webtoons: webtoons, autoUpdate: autoUpdate, categories: categories, writers: writers, studios: studios, theme: theme)
         if let data = try? JSONEncoder().encode(saved) {
             try? data.write(to: saveURL)
+        }
+    }
+
+    func changeTheme(_ value: String) {
+        theme = value
+    }
+
+    var colorScheme: ColorScheme? {
+        switch theme {
+        case "light":
+            return .light
+        case "dark":
+            return .dark
+        default:
+            return nil
+        }
+    }
+
+    var tintColor: Color {
+        switch theme {
+        case "sepia":
+            return Color(red: 0.6, green: 0.5, blue: 0.4)
+        case "poster":
+            return .orange
+        default:
+            return .accentColor
         }
     }
 }

--- a/WebtoonManager/ViewModels/WebtoonStore.swift
+++ b/WebtoonManager/ViewModels/WebtoonStore.swift
@@ -15,6 +15,11 @@ class WebtoonStore: ObservableObject {
         webtoons.append(webtoon)
     }
 
+    func update(_ webtoon: Webtoon) {
+        guard let index = webtoons.firstIndex(where: { $0.id == webtoon.id }) else { return }
+        webtoons[index] = webtoon
+    }
+
     func startAutoUpdate() {
         timer?.invalidate()
         guard autoUpdate else { return }

--- a/WebtoonManager/ViewModels/WebtoonStore.swift
+++ b/WebtoonManager/ViewModels/WebtoonStore.swift
@@ -32,7 +32,10 @@ class WebtoonStore: ObservableObject {
     }
 
     func add(_ webtoon: Webtoon) {
-        webtoons.append(webtoon)
+        var new = webtoon
+        new.savedAt = Date()
+        new.lastAccess = new.savedAt
+        webtoons.append(new)
         insertLists(from: webtoon)
     }
 
@@ -40,6 +43,11 @@ class WebtoonStore: ObservableObject {
         guard let index = webtoons.firstIndex(where: { $0.id == webtoon.id }) else { return }
         webtoons[index] = webtoon
         insertLists(from: webtoon)
+    }
+
+    func touch(_ webtoon: Webtoon) {
+        guard let index = webtoons.firstIndex(where: { $0.id == webtoon.id }) else { return }
+        webtoons[index].lastAccess = Date()
     }
 
     func startAutoUpdate() {

--- a/WebtoonManager/ViewModels/WebtoonStore.swift
+++ b/WebtoonManager/ViewModels/WebtoonStore.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Combine
+
+class WebtoonStore: ObservableObject {
+    @Published var webtoons: [Webtoon] = []
+    @Published var autoUpdate: Bool = true
+
+    private var timer: Timer?
+
+    init() {
+        startAutoUpdate()
+    }
+
+    func add(_ webtoon: Webtoon) {
+        webtoons.append(webtoon)
+    }
+
+    func startAutoUpdate() {
+        timer?.invalidate()
+        guard autoUpdate else { return }
+        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            self?.fetchUpdates()
+        }
+    }
+
+    func fetchUpdates() {
+        // Placeholder for API fetch implementation
+        // This would call external APIs to refresh data
+        print("Fetching updates from API...")
+    }
+
+    func toggleAutoUpdate(_ enabled: Bool) {
+        autoUpdate = enabled
+        startAutoUpdate()
+    }
+}

--- a/WebtoonManager/ViewModels/WebtoonStore.swift
+++ b/WebtoonManager/ViewModels/WebtoonStore.swift
@@ -2,12 +2,26 @@ import Foundation
 import Combine
 
 class WebtoonStore: ObservableObject {
-    @Published var webtoons: [Webtoon] = []
-    @Published var autoUpdate: Bool = true
+    @Published var webtoons: [Webtoon] = [] {
+        didSet { save() }
+    }
+    @Published var autoUpdate: Bool = true {
+        didSet { save(); startAutoUpdate() }
+    }
 
     private var timer: Timer?
+    private let saveURL: URL = {
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        return dir.appendingPathComponent("webtoons.json")
+    }()
+
+    private struct SavedData: Codable {
+        var webtoons: [Webtoon]
+        var autoUpdate: Bool
+    }
 
     init() {
+        load()
         startAutoUpdate()
     }
 
@@ -37,5 +51,19 @@ class WebtoonStore: ObservableObject {
     func toggleAutoUpdate(_ enabled: Bool) {
         autoUpdate = enabled
         startAutoUpdate()
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: saveURL),
+              let saved = try? JSONDecoder().decode(SavedData.self, from: data) else { return }
+        webtoons = saved.webtoons
+        autoUpdate = saved.autoUpdate
+    }
+
+    private func save() {
+        let saved = SavedData(webtoons: webtoons, autoUpdate: autoUpdate)
+        if let data = try? JSONEncoder().encode(saved) {
+            try? data.write(to: saveURL)
+        }
     }
 }

--- a/WebtoonManager/Views/AddWebtoonView.swift
+++ b/WebtoonManager/Views/AddWebtoonView.swift
@@ -52,7 +52,7 @@ struct AddWebtoonView: View {
                 }
                 ForEach(categories.indices, id: \.self) { i in
                     HStack {
-                        TextField("카테고리", text: $categories[i])
+                        TextField("장르", text: $categories[i])
                             .onSubmit { if i == categories.count - 1 { categories.append("") } }
                         if categories.count > 1 {
                             Button(action: { categories.remove(at: i) }) {

--- a/WebtoonManager/Views/AddWebtoonView.swift
+++ b/WebtoonManager/Views/AddWebtoonView.swift
@@ -12,6 +12,7 @@ struct AddWebtoonView: View {
     @State private var episodes: Int = 0
     @State private var lastRead: Int = 0
     @State private var review: String = ""
+    @State private var thumbnailURL: String = ""
 
     var body: some View {
         Form {
@@ -20,6 +21,7 @@ struct AddWebtoonView: View {
                 TextField("작가", text: $writer)
                 TextField("스튜디오", text: $studio)
                 TextField("카테고리", text: $category)
+                TextField("썸네일 URL", text: $thumbnailURL)
                 Picker("연재 상태", selection: $status) {
                     ForEach(WebtoonStatus.allCases) { Text($0.rawValue).tag($0) }
                 }
@@ -39,7 +41,7 @@ struct AddWebtoonView: View {
                 TextEditor(text: $review)
             }
             Button("저장") {
-                let new = Webtoon(id: UUID(), title: title, writer: writer, studio: studio, category: category, status: status, rating: rating, episodes: episodes, lastRead: lastRead, review: review)
+                let new = Webtoon(title: title, writer: writer, studio: studio, category: category, status: status, rating: rating, episodes: episodes, lastRead: lastRead, review: review, thumbnailURL: thumbnailURL)
                 store.add(new)
                 clear()
             }
@@ -57,6 +59,7 @@ struct AddWebtoonView: View {
         episodes = 0
         lastRead = 0
         review = ""
+        thumbnailURL = ""
     }
 }
 

--- a/WebtoonManager/Views/AddWebtoonView.swift
+++ b/WebtoonManager/Views/AddWebtoonView.swift
@@ -1,27 +1,77 @@
 import SwiftUI
+import PhotosUI
 
 struct AddWebtoonView: View {
     @ObservedObject var store: WebtoonStore
+    var existing: Webtoon?
+    @Environment(\.dismiss) private var dismiss
 
-    @State private var title: String = ""
-    @State private var writer: String = ""
-    @State private var studio: String = ""
-    @State private var category: String = ""
-    @State private var status: WebtoonStatus = .ongoing
-    @State private var rating: WebtoonRating = .average
-    @State private var episodes: Int = 0
-    @State private var lastRead: Int = 0
-    @State private var review: String = ""
-    @State private var thumbnailURL: String = ""
+    @State private var title: String
+    @State private var writers: [String]
+    @State private var studio: String
+    @State private var categories: [String]
+    @State private var status: WebtoonStatus
+    @State private var rating: WebtoonRating
+    @State private var episodes: String
+    @State private var lastRead: String
+    @State private var review: String
+    @State private var thumbnailURL: String
+    @State private var imageData: Data?
+    @State private var pickerItem: PhotosPickerItem?
+
+    init(store: WebtoonStore, webtoon: Webtoon? = nil) {
+        self.store = store
+        self.existing = webtoon
+        _title = State(initialValue: webtoon?.title ?? "")
+        _writers = State(initialValue: webtoon?.writers ?? [""])
+        _studio = State(initialValue: webtoon?.studio ?? "")
+        _categories = State(initialValue: webtoon?.categories ?? [""])
+        _status = State(initialValue: webtoon?.status ?? .ongoing)
+        _rating = State(initialValue: webtoon?.rating ?? .average)
+        _episodes = State(initialValue: webtoon != nil ? String(webtoon!.episodes) : "")
+        _lastRead = State(initialValue: webtoon != nil ? String(webtoon!.lastRead) : "")
+        _review = State(initialValue: webtoon?.review ?? "")
+        _thumbnailURL = State(initialValue: webtoon?.thumbnailURL ?? "")
+        _imageData = State(initialValue: webtoon?.thumbnailData)
+    }
 
     var body: some View {
         Form {
             Section(header: Text("기본 정보")) {
                 TextField("제목", text: $title)
-                TextField("작가", text: $writer)
+                ForEach(writers.indices, id: \.self) { i in
+                    HStack {
+                        TextField("작가", text: $writers[i])
+                            .onSubmit { if i == writers.count - 1 { writers.append("") } }
+                        if writers.count > 1 {
+                            Button(action: { writers.remove(at: i) }) {
+                                Image(systemName: "minus.circle")
+                            }
+                        }
+                    }
+                }
+                ForEach(categories.indices, id: \.self) { i in
+                    HStack {
+                        TextField("카테고리", text: $categories[i])
+                            .onSubmit { if i == categories.count - 1 { categories.append("") } }
+                        if categories.count > 1 {
+                            Button(action: { categories.remove(at: i) }) {
+                                Image(systemName: "minus.circle")
+                            }
+                        }
+                    }
+                }
                 TextField("스튜디오", text: $studio)
-                TextField("카테고리", text: $category)
                 TextField("썸네일 URL", text: $thumbnailURL)
+                if let data = imageData, let ui = UIImage(data: data) {
+                    Image(uiImage: ui).resizable().scaledToFit().frame(height: 100)
+                }
+                PhotosPicker(selection: $pickerItem, matching: .images) {
+                    Text("이미지 선택")
+                }
+                .onChange(of: pickerItem) { item in
+                    if let item { Task { imageData = try? await item.loadTransferable(type: Data.self) } }
+                }
                 Picker("연재 상태", selection: $status) {
                     ForEach(WebtoonStatus.allCases) { Text($0.rawValue).tag($0) }
                 }
@@ -30,36 +80,45 @@ struct AddWebtoonView: View {
                 }
             }
             Section(header: Text("회차")) {
-                Stepper(value: $episodes, in: 0...1000) {
-                    Text("총 회차: \(episodes)")
-                }
-                Stepper(value: $lastRead, in: 0...episodes) {
-                    Text("마지막으로 읽은 회차: \(lastRead)")
-                }
+                TextField("총 회차", text: $episodes)
+                    .keyboardType(.numberPad)
+                TextField("마지막으로 읽은 회차", text: $lastRead)
+                    .keyboardType(.numberPad)
+                    .onChange(of: lastRead) { newValue in
+                        if let e = Int(episodes), let l = Int(newValue), l > e { lastRead = episodes }
+                    }
             }
             Section(header: Text("리뷰")) {
                 TextEditor(text: $review)
             }
             Button("저장") {
-                let new = Webtoon(title: title, writer: writer, studio: studio, category: category, status: status, rating: rating, episodes: episodes, lastRead: lastRead, review: review, thumbnailURL: thumbnailURL)
-                store.add(new)
+                let epi = Int(episodes) ?? 0
+                let last = min(Int(lastRead) ?? 0, epi)
+                let new = Webtoon(id: existing?.id ?? UUID(), title: title, writers: writers.filter{ !$0.isEmpty }, studio: studio, categories: categories.filter{ !$0.isEmpty }, status: status, rating: rating, episodes: epi, lastRead: last, review: review, thumbnailURL: thumbnailURL, thumbnailData: imageData)
+                if existing != nil {
+                    store.update(new)
+                } else {
+                    store.add(new)
+                }
                 clear()
+                dismiss()
             }
-            Button("취소") { clear() }
+            Button("취소") { dismiss() }
         }
     }
 
     private func clear() {
         title = ""
-        writer = ""
+        writers = [""]
         studio = ""
-        category = ""
+        categories = [""]
         status = .ongoing
         rating = .average
-        episodes = 0
-        lastRead = 0
+        episodes = ""
+        lastRead = ""
         review = ""
         thumbnailURL = ""
+        imageData = nil
     }
 }
 

--- a/WebtoonManager/Views/AddWebtoonView.swift
+++ b/WebtoonManager/Views/AddWebtoonView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct AddWebtoonView: View {
+    @ObservedObject var store: WebtoonStore
+
+    @State private var title: String = ""
+    @State private var writer: String = ""
+    @State private var studio: String = ""
+    @State private var category: String = ""
+    @State private var status: WebtoonStatus = .ongoing
+    @State private var rating: WebtoonRating = .average
+    @State private var episodes: Int = 0
+    @State private var lastRead: Int = 0
+    @State private var review: String = ""
+
+    var body: some View {
+        Form {
+            Section(header: Text("기본 정보")) {
+                TextField("제목", text: $title)
+                TextField("작가", text: $writer)
+                TextField("스튜디오", text: $studio)
+                TextField("카테고리", text: $category)
+                Picker("연재 상태", selection: $status) {
+                    ForEach(WebtoonStatus.allCases) { Text($0.rawValue).tag($0) }
+                }
+                Picker("평가", selection: $rating) {
+                    ForEach(WebtoonRating.allCases) { Text($0.rawValue).tag($0) }
+                }
+            }
+            Section(header: Text("회차")) {
+                Stepper(value: $episodes, in: 0...1000) {
+                    Text("총 회차: \(episodes)")
+                }
+                Stepper(value: $lastRead, in: 0...episodes) {
+                    Text("마지막으로 읽은 회차: \(lastRead)")
+                }
+            }
+            Section(header: Text("리뷰")) {
+                TextEditor(text: $review)
+            }
+            Button("저장") {
+                let new = Webtoon(id: UUID(), title: title, writer: writer, studio: studio, category: category, status: status, rating: rating, episodes: episodes, lastRead: lastRead, review: review)
+                store.add(new)
+                clear()
+            }
+            Button("취소") { clear() }
+        }
+    }
+
+    private func clear() {
+        title = ""
+        writer = ""
+        studio = ""
+        category = ""
+        status = .ongoing
+        rating = .average
+        episodes = 0
+        lastRead = 0
+        review = ""
+    }
+}
+
+#Preview {
+    AddWebtoonView(store: WebtoonStore())
+}

--- a/WebtoonManager/Views/CategoryManagementView.swift
+++ b/WebtoonManager/Views/CategoryManagementView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct CategoryManagementView: View {
+    @ObservedObject var store: WebtoonStore
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        List {
+            Section(header: Text("카테고리")) {
+                ForEach(store.categories.indices, id: \.self) { i in
+                    TextField("카테고리", text: Binding(
+                        get: { store.categories[i] },
+                        set: { store.renameCategory(at: i, new: $0) }
+                    ))
+                }
+                .onDelete(perform: store.deleteCategory)
+                Button("추가") { store.categories.append("") }
+            }
+            Section(header: Text("작가")) {
+                ForEach(store.writers.indices, id: \.self) { i in
+                    TextField("작가", text: Binding(
+                        get: { store.writers[i] },
+                        set: { store.renameWriter(at: i, new: $0) }
+                    ))
+                }
+                .onDelete(perform: store.deleteWriter)
+                Button("추가") { store.writers.append("") }
+            }
+            Section(header: Text("스튜디오")) {
+                ForEach(store.studios.indices, id: \.self) { i in
+                    TextField("스튜디오", text: Binding(
+                        get: { store.studios[i] },
+                        set: { store.renameStudio(at: i, new: $0) }
+                    ))
+                }
+                .onDelete(perform: store.deleteStudio)
+                Button("추가") { store.studios.append("") }
+            }
+        }
+        .navigationTitle("카테고리 관리")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button("뒤로") { dismiss() }
+            }
+        }
+    }
+}
+
+#Preview {
+    CategoryManagementView(store: WebtoonStore())
+}

--- a/WebtoonManager/Views/CategoryManagementView.swift
+++ b/WebtoonManager/Views/CategoryManagementView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CategoryManagementView: View {
     @ObservedObject var store: WebtoonStore
     @Environment(\.dismiss) var dismiss
+    @State private var editMode: EditMode = .inactive
 
     var body: some View {
         List {
@@ -42,7 +43,11 @@ struct CategoryManagementView: View {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button("뒤로") { dismiss() }
             }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                EditButton()
+            }
         }
+        .environment(\.editMode, $editMode)
     }
 }
 

--- a/WebtoonManager/Views/CategoryManagementView.swift
+++ b/WebtoonManager/Views/CategoryManagementView.swift
@@ -6,9 +6,9 @@ struct CategoryManagementView: View {
 
     var body: some View {
         List {
-            Section(header: Text("카테고리")) {
+            Section(header: Text("장르")) {
                 ForEach(store.categories.indices, id: \.self) { i in
-                    TextField("카테고리", text: Binding(
+                    TextField("장르", text: Binding(
                         get: { store.categories[i] },
                         set: { store.renameCategory(at: i, new: $0) }
                     ))

--- a/WebtoonManager/Views/ContentView.swift
+++ b/WebtoonManager/Views/ContentView.swift
@@ -22,6 +22,8 @@ struct ContentView: View {
                 .tabItem { Label("기타", systemImage: "gear") }
                 .tag(3)
         }
+        .preferredColorScheme(store.colorScheme)
+        .tint(store.tintColor)
     }
 }
 

--- a/WebtoonManager/Views/ContentView.swift
+++ b/WebtoonManager/Views/ContentView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var store = WebtoonStore()
+    
+    var body: some View {
+        TabView {
+            HomeView(store: store)
+                .tabItem {
+                    Label("홈", systemImage: "house")
+                }
+
+            SearchView(store: store)
+                .tabItem {
+                    Label("검색", systemImage: "magnifyingglass")
+                }
+
+            AddWebtoonView(store: store)
+                .tabItem {
+                    Label("추가", systemImage: "plus.circle")
+                }
+
+            SettingsView(store: store)
+                .tabItem {
+                    Label("기타", systemImage: "gear")
+                }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/WebtoonManager/Views/ContentView.swift
+++ b/WebtoonManager/Views/ContentView.swift
@@ -2,28 +2,25 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var store = WebtoonStore()
+    @AppStorage("selectedTab") private var selectedTab: Int = 0
     
     var body: some View {
-        TabView {
+        TabView(selection: $selectedTab) {
             HomeView(store: store)
-                .tabItem {
-                    Label("홈", systemImage: "house")
-                }
+                .tabItem { Label("홈", systemImage: "house") }
+                .tag(0)
 
             SearchView(store: store)
-                .tabItem {
-                    Label("검색", systemImage: "magnifyingglass")
-                }
+                .tabItem { Label("검색", systemImage: "magnifyingglass") }
+                .tag(1)
 
             AddWebtoonView(store: store)
-                .tabItem {
-                    Label("추가", systemImage: "plus.circle")
-                }
+                .tabItem { Label("추가", systemImage: "plus.circle") }
+                .tag(2)
 
             SettingsView(store: store)
-                .tabItem {
-                    Label("기타", systemImage: "gear")
-                }
+                .tabItem { Label("기타", systemImage: "gear") }
+                .tag(3)
         }
     }
 }

--- a/WebtoonManager/Views/HomeView.swift
+++ b/WebtoonManager/Views/HomeView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct HomeView: View {
+    @ObservedObject var store: WebtoonStore
+    @State private var searchText = ""
+
+    var body: some View {
+        VStack {
+            Image("AppLogo")
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: 390)
+                .padding()
+
+            TextField("검색", text: $searchText)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding([.horizontal])
+                .onChange(of: searchText) { _ in
+                    // Could update search results in real time
+                }
+
+            Spacer()
+        }
+        .background(Color.white)
+    }
+}
+
+#Preview {
+    HomeView(store: WebtoonStore())
+}

--- a/WebtoonManager/Views/HomeView.swift
+++ b/WebtoonManager/Views/HomeView.swift
@@ -9,7 +9,7 @@ struct HomeView: View {
             Image("AppLogo")
                 .resizable()
                 .scaledToFit()
-                .frame(maxWidth: 390)
+                .frame(maxWidth: UIScreen.main.bounds.width * 0.8)
                 .padding()
 
             TextField("검색", text: $searchText)

--- a/WebtoonManager/Views/LoadingView.swift
+++ b/WebtoonManager/Views/LoadingView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct LoadingView: View {
+    var body: some View {
+        VStack {
+            Spacer()
+            Image("AppLogo")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 200, height: 200)
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle())
+                .padding()
+            Spacer()
+        }
+        .background(Color.white)
+    }
+}
+
+#Preview {
+    LoadingView()
+}

--- a/WebtoonManager/Views/SearchView.swift
+++ b/WebtoonManager/Views/SearchView.swift
@@ -4,18 +4,26 @@ struct SearchView: View {
     @ObservedObject var store: WebtoonStore
     @State private var searchText = ""
     @State private var sortOption = 0
+    @State private var editingWebtoon: Webtoon?
+    @State private var isEditing = false
 
     var filtered: [Webtoon] {
         if searchText.isEmpty { return store.webtoons }
-        return store.webtoons.filter { $0.title.contains(searchText) || $0.writer.contains(searchText) || $0.studio.contains(searchText) || $0.category.contains(searchText) }
+        return store.webtoons.filter { $0.title.contains(searchText) || $0.writers.joined().contains(searchText) || $0.studio.contains(searchText) || $0.categories.joined().contains(searchText) }
     }
 
     var body: some View {
         NavigationStack {
             VStack {
-                TextField("검색", text: $searchText)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .padding([.horizontal])
+                HStack {
+                    TextField("검색", text: $searchText)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    Spacer()
+                    Button("편집") { isEditing.toggle() }
+                        .font(.footnote)
+                        .foregroundColor(.gray)
+                }
+                .padding([.horizontal])
 
             Picker("정렬", selection: $sortOption) {
                 Text("평가 순").tag(0)
@@ -28,21 +36,32 @@ struct SearchView: View {
                 List(filtered) { webtoon in
                     NavigationLink(destination: WebtoonDetailView(store: store, webtoon: webtoon)) {
                         HStack {
-                            AsyncImage(url: URL(string: webtoon.thumbnailURL)) { phase in
-                                switch phase {
-                                case .success(let image):
-                                    image.resizable().scaledToFit().frame(width: 70, height: 100)
-                                default:
-                                    Rectangle().fill(Color.gray).frame(width: 70, height: 100)
+                            if let data = webtoon.thumbnailData, let ui = UIImage(data: data) {
+                                Image(uiImage: ui).resizable().scaledToFit().frame(width: 70, height: 100)
+                            } else {
+                                AsyncImage(url: URL(string: webtoon.thumbnailURL)) { phase in
+                                    switch phase {
+                                    case .success(let image):
+                                        image.resizable().scaledToFit().frame(width: 70, height: 100)
+                                    default:
+                                        Rectangle().fill(Color.gray).frame(width: 70, height: 100)
+                                    }
                                 }
                             }
                             VStack(alignment: .leading) {
                                 Text(webtoon.title).font(.headline)
-                                Text(webtoon.writer).foregroundColor(.secondary)
+                                Text(webtoon.writers.joined(separator: ", "))
+                                    .foregroundColor(.secondary)
                                 Text(webtoon.rating.rawValue)
                                 Text(webtoon.status.rawValue)
                             }
                         }
+                    }
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) { delete(webtoon) } label: { Label("삭제", systemImage: "trash") }
+                    }
+                    .swipeActions(edge: .leading) {
+                        Button { editingWebtoon = webtoon } label: { Label("편집", systemImage: "pencil") }
                     }
                 }
             }
@@ -50,6 +69,9 @@ struct SearchView: View {
                 sort()
             }
             .navigationTitle("웹툰 검색")
+            .sheet(item: $editingWebtoon) { webtoon in
+                AddWebtoonView(store: store, webtoon: webtoon)
+            }
         }
     }
 
@@ -62,6 +84,10 @@ struct SearchView: View {
         default:
             break
         }
+    }
+
+    private func delete(_ webtoon: Webtoon) {
+        store.webtoons.removeAll { $0.id == webtoon.id }
     }
 }
 

--- a/WebtoonManager/Views/SearchView.swift
+++ b/WebtoonManager/Views/SearchView.swift
@@ -61,7 +61,7 @@ struct SearchView: View {
                                         .font(.subheadline)
                                 }
                                 if !webtoon.categories.isEmpty {
-                                    Text("카테고리: \(webtoon.categories.joined(separator: ", "))")
+                                    Text("장르: \(webtoon.categories.joined(separator: ", "))")
                                         .font(.subheadline)
                                 }
                             }

--- a/WebtoonManager/Views/SearchView.swift
+++ b/WebtoonManager/Views/SearchView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct SearchView: View {
+    @ObservedObject var store: WebtoonStore
+    @State private var searchText = ""
+    @State private var sortOption = 0
+
+    var filtered: [Webtoon] {
+        if searchText.isEmpty { return store.webtoons }
+        return store.webtoons.filter { $0.title.contains(searchText) || $0.writer.contains(searchText) || $0.studio.contains(searchText) || $0.category.contains(searchText) }
+    }
+
+    var body: some View {
+        VStack {
+            TextField("검색", text: $searchText)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding([.horizontal])
+
+            Picker("정렬", selection: $sortOption) {
+                Text("평가 순").tag(0)
+                Text("제목 순").tag(1)
+                Text("최근 클릭 순").tag(2)
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .padding([.horizontal])
+
+            List(filtered) { webtoon in
+                HStack {
+                    Rectangle()
+                        .fill(Color.gray)
+                        .frame(width: 70, height: 100)
+                    VStack(alignment: .leading) {
+                        Text(webtoon.title).font(.headline)
+                        Text(webtoon.writer).foregroundColor(.secondary)
+                        Text(webtoon.rating.rawValue)
+                        Text(webtoon.status.rawValue)
+                    }
+                }
+            }
+        }
+        .onChange(of: sortOption) { _ in
+            // Sorting logic placeholder
+        }
+    }
+}
+
+#Preview {
+    SearchView(store: WebtoonStore())
+}

--- a/WebtoonManager/Views/SearchView.swift
+++ b/WebtoonManager/Views/SearchView.swift
@@ -11,10 +11,11 @@ struct SearchView: View {
     }
 
     var body: some View {
-        VStack {
-            TextField("검색", text: $searchText)
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-                .padding([.horizontal])
+        NavigationStack {
+            VStack {
+                TextField("검색", text: $searchText)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding([.horizontal])
 
             Picker("정렬", selection: $sortOption) {
                 Text("평가 순").tag(0)
@@ -24,22 +25,42 @@ struct SearchView: View {
             .pickerStyle(SegmentedPickerStyle())
             .padding([.horizontal])
 
-            List(filtered) { webtoon in
-                HStack {
-                    Rectangle()
-                        .fill(Color.gray)
-                        .frame(width: 70, height: 100)
-                    VStack(alignment: .leading) {
-                        Text(webtoon.title).font(.headline)
-                        Text(webtoon.writer).foregroundColor(.secondary)
-                        Text(webtoon.rating.rawValue)
-                        Text(webtoon.status.rawValue)
+                List(filtered) { webtoon in
+                    NavigationLink(destination: WebtoonDetailView(store: store, webtoon: webtoon)) {
+                        HStack {
+                            AsyncImage(url: URL(string: webtoon.thumbnailURL)) { phase in
+                                switch phase {
+                                case .success(let image):
+                                    image.resizable().scaledToFit().frame(width: 70, height: 100)
+                                default:
+                                    Rectangle().fill(Color.gray).frame(width: 70, height: 100)
+                                }
+                            }
+                            VStack(alignment: .leading) {
+                                Text(webtoon.title).font(.headline)
+                                Text(webtoon.writer).foregroundColor(.secondary)
+                                Text(webtoon.rating.rawValue)
+                                Text(webtoon.status.rawValue)
+                            }
+                        }
                     }
                 }
             }
+            .onChange(of: sortOption) { _ in
+                sort()
+            }
+            .navigationTitle("웹툰 검색")
         }
-        .onChange(of: sortOption) { _ in
-            // Sorting logic placeholder
+    }
+
+    private func sort() {
+        switch sortOption {
+        case 0:
+            store.webtoons.sort { $0.rating.rawValue > $1.rating.rawValue }
+        case 1:
+            store.webtoons.sort { $0.title < $1.title }
+        default:
+            break
         }
     }
 }

--- a/WebtoonManager/Views/SearchView.swift
+++ b/WebtoonManager/Views/SearchView.swift
@@ -6,6 +6,7 @@ struct SearchView: View {
     @State private var sortOption = 0
     @State private var editingWebtoon: Webtoon?
     @State private var isEditing = false
+    @State private var editMode: EditMode = .inactive
 
     var filtered: [Webtoon] {
         if searchText.isEmpty { return store.webtoons }
@@ -24,6 +25,7 @@ struct SearchView: View {
                         .foregroundColor(.gray)
                 }
                 .padding([.horizontal])
+                .onChange(of: isEditing) { editMode = $0 ? .active : .inactive }
 
             Picker("정렬", selection: $sortOption) {
                 Text("평가 순").tag(0)
@@ -33,8 +35,9 @@ struct SearchView: View {
             .pickerStyle(SegmentedPickerStyle())
             .padding([.horizontal])
 
-                List(filtered) { webtoon in
-                    NavigationLink(destination: WebtoonDetailView(store: store, webtoon: webtoon)) {
+                List {
+                    ForEach(filtered) { webtoon in
+                        NavigationLink(destination: WebtoonDetailView(store: store, webtoon: webtoon)) {
                         HStack {
                             if let data = webtoon.thumbnailData, let ui = UIImage(data: data) {
                                 Image(uiImage: ui).resizable().scaledToFit().frame(width: 70, height: 100)
@@ -73,7 +76,12 @@ struct SearchView: View {
                     .swipeActions(edge: .leading) {
                         Button { editingWebtoon = webtoon } label: { Label("편집", systemImage: "pencil") }
                     }
+                    }
+                    .onDelete { offsets in
+                        offsets.map { filtered[$0] }.forEach(delete)
+                    }
                 }
+                .environment(\.editMode, $editMode)
             }
             .onChange(of: sortOption) { _ in
                 sort()

--- a/WebtoonManager/Views/SearchView.swift
+++ b/WebtoonManager/Views/SearchView.swift
@@ -52,8 +52,18 @@ struct SearchView: View {
                                 Text(webtoon.title).font(.headline)
                                 Text(webtoon.writers.joined(separator: ", "))
                                     .foregroundColor(.secondary)
-                                Text(webtoon.rating.rawValue)
-                                Text(webtoon.status.rawValue)
+                                Text("평가: \(webtoon.rating.rawValue)")
+                                    .font(.subheadline)
+                                Text("연재 상태: \(webtoon.status.rawValue)")
+                                    .font(.subheadline)
+                                if !webtoon.studio.isEmpty {
+                                    Text("스튜디오: \(webtoon.studio)")
+                                        .font(.subheadline)
+                                }
+                                if !webtoon.categories.isEmpty {
+                                    Text("카테고리: \(webtoon.categories.joined(separator: ", "))")
+                                        .font(.subheadline)
+                                }
                             }
                         }
                     }
@@ -68,6 +78,7 @@ struct SearchView: View {
             .onChange(of: sortOption) { _ in
                 sort()
             }
+            .onAppear { sort() }
             .navigationTitle("웹툰 검색")
             .sheet(item: $editingWebtoon) { webtoon in
                 AddWebtoonView(store: store, webtoon: webtoon)
@@ -81,6 +92,8 @@ struct SearchView: View {
             store.webtoons.sort { $0.rating.rawValue > $1.rating.rawValue }
         case 1:
             store.webtoons.sort { $0.title < $1.title }
+        case 2:
+            store.webtoons.sort { $0.lastAccess > $1.lastAccess }
         default:
             break
         }

--- a/WebtoonManager/Views/SettingsView.swift
+++ b/WebtoonManager/Views/SettingsView.swift
@@ -11,6 +11,17 @@ struct SettingsView: View {
                     set: { store.toggleAutoUpdate($0) }
                 ))
 
+                Picker("테마", selection: Binding(
+                    get: { store.theme },
+                    set: { store.changeTheme($0) }
+                )) {
+                    Text("시스템").tag("system")
+                    Text("라이트").tag("light")
+                    Text("다크").tag("dark")
+                    Text("세피아").tag("sepia")
+                    Text("포스터 뷰").tag("poster")
+                }
+
                 NavigationLink("카테고리 관리") {
                     CategoryManagementView(store: store)
                 }

--- a/WebtoonManager/Views/SettingsView.swift
+++ b/WebtoonManager/Views/SettingsView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var store: WebtoonStore
+
+    var body: some View {
+        Form {
+            Toggle("자동 업데이트", isOn: Binding(
+                get: { store.autoUpdate },
+                set: { store.toggleAutoUpdate($0) }
+            ))
+        }
+    }
+}
+
+#Preview {
+    SettingsView(store: WebtoonStore())
+}

--- a/WebtoonManager/Views/SettingsView.swift
+++ b/WebtoonManager/Views/SettingsView.swift
@@ -4,11 +4,18 @@ struct SettingsView: View {
     @ObservedObject var store: WebtoonStore
 
     var body: some View {
-        Form {
-            Toggle("자동 업데이트", isOn: Binding(
-                get: { store.autoUpdate },
-                set: { store.toggleAutoUpdate($0) }
-            ))
+        NavigationStack {
+            Form {
+                Toggle("자동 업데이트", isOn: Binding(
+                    get: { store.autoUpdate },
+                    set: { store.toggleAutoUpdate($0) }
+                ))
+
+                NavigationLink("카테고리 관리") {
+                    CategoryManagementView(store: store)
+                }
+            }
+            .navigationTitle("기타")
         }
     }
 }

--- a/WebtoonManager/Views/WebtoonDetailView.swift
+++ b/WebtoonManager/Views/WebtoonDetailView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct WebtoonDetailView: View {
+    @ObservedObject var store: WebtoonStore
+    @State var webtoon: Webtoon
+    @State private var showMenu = false
+    @State private var showPicker = false
+
+    private var progress: Double {
+        guard webtoon.episodes > 0 else { return 0 }
+        return Double(webtoon.lastRead) / Double(webtoon.episodes)
+    }
+
+    private var progressText: String {
+        if webtoon.episodes == 0 { return "안 읽음" }
+        if webtoon.lastRead == 0 { return "안 읽음" }
+        if webtoon.lastRead >= webtoon.episodes { return "다 읽음" }
+        return "\(webtoon.lastRead)/\(webtoon.episodes)"
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                AsyncImage(url: URL(string: webtoon.thumbnailURL)) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image.resizable().scaledToFit().frame(maxWidth: .infinity)
+                    default:
+                        Rectangle().fill(Color.gray.opacity(0.3)).frame(height: 200)
+                    }
+                }
+
+                Text(webtoon.title).font(.largeTitle).bold()
+                Text(webtoon.writer).foregroundColor(.secondary)
+                progressBar
+                Text("카테고리: \(webtoon.category)")
+                Text("연재 상태: \(webtoon.status.rawValue)")
+                Text("평가: \(webtoon.rating.rawValue)")
+                TextEditor(text: $webtoon.review).frame(minHeight: 100)
+            }
+            .padding()
+        }
+        .navigationTitle(webtoon.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .confirmationDialog("진행 상태", isPresented: $showMenu) {
+            Button("안 읽음") { webtoon.lastRead = 0; update() }
+            Button("읽는 중") { showPicker = true }
+            Button("다 읽음") { webtoon.lastRead = webtoon.episodes; update() }
+        }
+        .sheet(isPresented: $showPicker) {
+            VStack {
+                Picker("회차", selection: $webtoon.lastRead) {
+                    ForEach(0...webtoon.episodes, id: \.self) { Text("\($0)").tag($0) }
+                }
+                .pickerStyle(WheelPickerStyle())
+                Button("확인") { update(); showPicker = false }
+            }.padding()
+        }
+    }
+
+    private var progressBar: some View {
+        ZStack {
+            GeometryReader { geo in
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.gray.opacity(0.3))
+                    .frame(height: 20)
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(webtoon.lastRead >= webtoon.episodes && webtoon.episodes > 0 ? Color.black : Color.yellow)
+                    .frame(width: geo.size.width * progress, height: 20)
+            }
+            Text(progressText)
+                .foregroundColor(webtoon.lastRead >= webtoon.episodes && webtoon.episodes > 0 ? .white : .black)
+        }
+        .frame(height: 20)
+        .onTapGesture { showMenu = true }
+    }
+
+    private func update() {
+        store.update(webtoon)
+    }
+}
+
+#Preview {
+    WebtoonDetailView(store: WebtoonStore(), webtoon: Webtoon(title: "Sample", writer: "Writer", studio: "Studio", category: "Category", status: .ongoing, rating: .average, episodes: 10, lastRead: 0, review: "", thumbnailURL: ""))
+}

--- a/WebtoonManager/Views/WebtoonDetailView.swift
+++ b/WebtoonManager/Views/WebtoonDetailView.swift
@@ -46,6 +46,7 @@ struct WebtoonDetailView: View {
         }
         .navigationTitle(webtoon.title)
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear { store.touch(webtoon) }
         .confirmationDialog("진행 상태", isPresented: $showMenu) {
             Button("안 읽음") { webtoon.lastRead = 0; update() }
             Button("읽는 중") { showPicker = true }

--- a/WebtoonManager/Views/WebtoonDetailView.swift
+++ b/WebtoonManager/Views/WebtoonDetailView.swift
@@ -21,19 +21,23 @@ struct WebtoonDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                AsyncImage(url: URL(string: webtoon.thumbnailURL)) { phase in
-                    switch phase {
-                    case .success(let image):
-                        image.resizable().scaledToFit().frame(maxWidth: .infinity)
-                    default:
-                        Rectangle().fill(Color.gray.opacity(0.3)).frame(height: 200)
+                if let data = webtoon.thumbnailData, let ui = UIImage(data: data) {
+                    Image(uiImage: ui).resizable().scaledToFit().frame(maxWidth: .infinity)
+                } else {
+                    AsyncImage(url: URL(string: webtoon.thumbnailURL)) { phase in
+                        switch phase {
+                        case .success(let image):
+                            image.resizable().scaledToFit().frame(maxWidth: .infinity)
+                        default:
+                            Rectangle().fill(Color.gray.opacity(0.3)).frame(height: 200)
+                        }
                     }
                 }
 
                 Text(webtoon.title).font(.largeTitle).bold()
-                Text(webtoon.writer).foregroundColor(.secondary)
+                Text(webtoon.writers.joined(separator: ", ")).foregroundColor(.secondary)
                 progressBar
-                Text("카테고리: \(webtoon.category)")
+                Text("카테고리: \(webtoon.categories.joined(separator: ", "))")
                 Text("연재 상태: \(webtoon.status.rawValue)")
                 Text("평가: \(webtoon.rating.rawValue)")
                 TextEditor(text: $webtoon.review).frame(minHeight: 100)
@@ -81,5 +85,5 @@ struct WebtoonDetailView: View {
 }
 
 #Preview {
-    WebtoonDetailView(store: WebtoonStore(), webtoon: Webtoon(title: "Sample", writer: "Writer", studio: "Studio", category: "Category", status: .ongoing, rating: .average, episodes: 10, lastRead: 0, review: "", thumbnailURL: ""))
+    WebtoonDetailView(store: WebtoonStore(), webtoon: Webtoon(title: "Sample", writers: ["Writer"], studio: "Studio", categories: ["Category"], status: .ongoing, rating: .average, episodes: 10, lastRead: 0, review: "", thumbnailURL: "", thumbnailData: nil))
 }

--- a/WebtoonManager/Views/WebtoonDetailView.swift
+++ b/WebtoonManager/Views/WebtoonDetailView.swift
@@ -37,7 +37,7 @@ struct WebtoonDetailView: View {
                 Text(webtoon.title).font(.largeTitle).bold()
                 Text(webtoon.writers.joined(separator: ", ")).foregroundColor(.secondary)
                 progressBar
-                Text("카테고리: \(webtoon.categories.joined(separator: ", "))")
+                Text("장르: \(webtoon.categories.joined(separator: ", "))")
                 Text("연재 상태: \(webtoon.status.rawValue)")
                 Text("평가: \(webtoon.rating.rawValue)")
                 TextEditor(text: $webtoon.review).frame(minHeight: 100)

--- a/WebtoonManager/WebtoonManagerApp.swift
+++ b/WebtoonManager/WebtoonManagerApp.swift
@@ -1,20 +1,41 @@
 import SwiftUI
+import Photos
 
 @main
 struct WebtoonManagerApp: App {
     @State private var isLoading = true
+    @AppStorage("didRequestPermissions") private var didRequestPermissions = false
+    @AppStorage("networkAllowed") private var networkAllowed = false
+    @State private var showNetworkAlert = false
 
     var body: some Scene {
         WindowGroup {
             if isLoading {
                 LoadingView()
                     .onAppear {
+                        requestPermissions()
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                             withAnimation { isLoading = false }
                         }
                     }
             } else {
                 ContentView()
+                    .alert("인터넷 연결 허용", isPresented: $showNetworkAlert) {
+                        Button("허용") { networkAllowed = true }
+                        Button("허용 안함", role: .cancel) { networkAllowed = false }
+                    } message: {
+                        Text("자동 업데이트를 위해 인터넷 연결을 사용합니다.")
+                    }
+            }
+        }
+    }
+
+    private func requestPermissions() {
+        guard !didRequestPermissions else { return }
+        PHPhotoLibrary.requestAuthorization(for: .readWrite) { _ in
+            DispatchQueue.main.async {
+                didRequestPermissions = true
+                showNetworkAlert = true
             }
         }
     }

--- a/WebtoonManager/WebtoonManagerApp.swift
+++ b/WebtoonManager/WebtoonManagerApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct WebtoonManagerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/WebtoonManager/WebtoonManagerApp.swift
+++ b/WebtoonManager/WebtoonManagerApp.swift
@@ -2,9 +2,20 @@ import SwiftUI
 
 @main
 struct WebtoonManagerApp: App {
+    @State private var isLoading = true
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            if isLoading {
+                LoadingView()
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                            withAnimation { isLoading = false }
+                        }
+                    }
+            } else {
+                ContentView()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- create SwiftUI skeleton with TabView for home, search, add, and settings
- implement simple Webtoon model and store
- placeholder API update timer and toggle
- show custom `AppLogo` on home page and update README

## Testing
- `swift --version`
- `swiftc WebtoonManagerApp.swift Models/Webtoon.swift ViewModels/WebtoonStore.swift Views/*.swift -o /tmp/webtoon_app` *(fails: no module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68824fe1aa84832b998dcd205df266ee