### PR TITLE
Implement editing flow and UI fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Copy `WebtoonManager/Info.plist` into your project or make sure your own Info.pl
 - Search results lead to a detail view with a progress bar for reading status.
 - Basic data model for storing webtoon info including thumbnail URL.
 - Automatic API updates can run while the app is open when enabled in Settings.
-- Home page displays your own `AppLogo` image scaled to about 390pt width (add a square asset named `AppLogo`, recommended size 886×886 at 132 DPI).
+- Home page displays your own `AppLogo` image scaled to about 390pt width. Add any square asset named `AppLogo` and it will be resized automatically.
 - App remembers the last selected tab and saved webtoons across launches.
 - Edit or delete saved webtoons in the Search tab via swipe actions. Sorting options include rating, title or most recent click.
 - Add multiple writers and genres, numeric episode fields and local image selection when creating or editing webtoons.

--- a/WebtoonManager/Models/Webtoon.swift
+++ b/WebtoonManager/Models/Webtoon.swift
@@ -9,12 +9,21 @@ enum WebtoonStatus: String, CaseIterable, Identifiable, Codable {
 }
 
 enum WebtoonRating: String, CaseIterable, Identifiable, Codable {
-    case poor = "졸작"
-    case average = "보통"
-    case good = "수작"
     case great = "명작"
+    case good = "수작"
+    case average = "보통"
+    case poor = "졸작"
 
     var id: String { rawValue }
+
+    var order: Int {
+        switch self {
+        case .great: return 4
+        case .good: return 3
+        case .average: return 2
+        case .poor: return 1
+        }
+    }
 }
 
 struct Webtoon: Identifiable, Codable, Equatable {

--- a/WebtoonManager/ViewModels/WebtoonStore.swift
+++ b/WebtoonManager/ViewModels/WebtoonStore.swift
@@ -13,6 +13,7 @@ class WebtoonStore: ObservableObject {
     @Published var writers: [String] = [] { didSet { save() } }
     @Published var studios: [String] = [] { didSet { save() } }
     @Published var theme: String = "system" { didSet { save() } }
+    @Published var editingWebtoon: Webtoon? = nil
 
     private var timer: Timer?
     private let saveURL: URL = {
@@ -46,6 +47,14 @@ class WebtoonStore: ObservableObject {
         guard let index = webtoons.firstIndex(where: { $0.id == webtoon.id }) else { return }
         webtoons[index] = webtoon
         insertLists(from: webtoon)
+    }
+
+    func beginEditing(_ webtoon: Webtoon) {
+        editingWebtoon = webtoon
+    }
+
+    func finishEditing() {
+        editingWebtoon = nil
     }
 
     func touch(_ webtoon: Webtoon) {

--- a/WebtoonManager/Views/AddWebtoonView.swift
+++ b/WebtoonManager/Views/AddWebtoonView.swift
@@ -6,6 +6,8 @@ struct AddWebtoonView: View {
     var existing: Webtoon?
     @Environment(\.dismiss) private var dismiss
 
+    @State private var editingId: UUID?
+
     @State private var title: String
     @State private var writers: [String]
     @State private var studio: String
@@ -33,6 +35,29 @@ struct AddWebtoonView: View {
         _review = State(initialValue: webtoon?.review ?? "")
         _thumbnailURL = State(initialValue: webtoon?.thumbnailURL ?? "")
         _imageData = State(initialValue: webtoon?.thumbnailData)
+        _editingId = State(initialValue: webtoon?.id)
+    }
+
+    private func loadFromEditing() {
+        let w = existing ?? store.editingWebtoon
+        guard editingId != w?.id else { return }
+        if let w {
+            title = w.title
+            writers = w.writers
+            studio = w.studio
+            categories = w.categories
+            status = w.status
+            rating = w.rating
+            episodes = String(w.episodes)
+            lastRead = String(w.lastRead)
+            review = w.review
+            thumbnailURL = w.thumbnailURL
+            imageData = w.thumbnailData
+            editingId = w.id
+        } else {
+            clear()
+            editingId = nil
+        }
     }
 
     var body: some View {
@@ -101,10 +126,16 @@ struct AddWebtoonView: View {
                     store.add(new)
                 }
                 clear()
+                store.finishEditing()
                 dismiss()
             }
-            Button("취소") { dismiss() }
+            Button("취소") {
+                store.finishEditing()
+                dismiss()
+            }
         }
+        .onAppear { loadFromEditing() }
+        .onChange(of: store.editingWebtoon) { _ in loadFromEditing() }
     }
 
     private func clear() {

--- a/WebtoonManager/Views/AddWebtoonView.swift
+++ b/WebtoonManager/Views/AddWebtoonView.swift
@@ -119,8 +119,8 @@ struct AddWebtoonView: View {
             Button("저장") {
                 let epi = Int(episodes) ?? 0
                 let last = min(Int(lastRead) ?? 0, epi)
-                let new = Webtoon(id: existing?.id ?? UUID(), title: title, writers: writers.filter{ !$0.isEmpty }, studio: studio, categories: categories.filter{ !$0.isEmpty }, status: status, rating: rating, episodes: epi, lastRead: last, review: review, thumbnailURL: thumbnailURL, thumbnailData: imageData)
-                if existing != nil {
+                let new = Webtoon(id: editingId ?? existing?.id ?? UUID(), title: title, writers: writers.filter { !$0.isEmpty }, studio: studio, categories: categories.filter { !$0.isEmpty }, status: status, rating: rating, episodes: epi, lastRead: last, review: review, thumbnailURL: thumbnailURL, thumbnailData: imageData)
+                if editingId != nil || existing != nil {
                     store.update(new)
                 } else {
                     store.add(new)

--- a/WebtoonManager/Views/CategoryManagementView.swift
+++ b/WebtoonManager/Views/CategoryManagementView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct CategoryManagementView: View {
     @ObservedObject var store: WebtoonStore
-    @Environment(\.dismiss) var dismiss
     @State private var editMode: EditMode = .inactive
 
     var body: some View {
@@ -40,9 +39,6 @@ struct CategoryManagementView: View {
         }
         .navigationTitle("카테고리 관리")
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button("뒤로") { dismiss() }
-            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 EditButton()
             }

--- a/WebtoonManager/Views/HomeView.swift
+++ b/WebtoonManager/Views/HomeView.swift
@@ -21,7 +21,7 @@ struct HomeView: View {
 
             Spacer()
         }
-        .background(Color.white)
+        .background(Color(.systemBackground))
     }
 }
 

--- a/WebtoonManager/Views/SearchView.swift
+++ b/WebtoonManager/Views/SearchView.swift
@@ -20,7 +20,7 @@ struct SearchView: View {
                     TextField("검색", text: $searchText)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                     Spacer()
-                    Button("편집") { isEditing.toggle() }
+                    Button(isEditing ? "확인" : "편집") { isEditing.toggle() }
                         .font(.footnote)
                         .foregroundColor(.gray)
                 }

--- a/WebtoonManager/Views/SearchView.swift
+++ b/WebtoonManager/Views/SearchView.swift
@@ -97,7 +97,7 @@ struct SearchView: View {
     private func sort() {
         switch sortOption {
         case 0:
-            store.webtoons.sort { $0.rating.rawValue > $1.rating.rawValue }
+            store.webtoons.sort { $0.rating.order > $1.rating.order }
         case 1:
             store.webtoons.sort { $0.title < $1.title }
         case 2:

--- a/WebtoonManager/Views/WebtoonDetailView.swift
+++ b/WebtoonManager/Views/WebtoonDetailView.swift
@@ -5,6 +5,7 @@ struct WebtoonDetailView: View {
     @State var webtoon: Webtoon
     @State private var showMenu = false
     @State private var showPicker = false
+    @AppStorage("selectedTab") private var selectedTab: Int = 0
 
     private var progress: Double {
         guard webtoon.episodes > 0 else { return 0 }
@@ -41,6 +42,11 @@ struct WebtoonDetailView: View {
                 Text("연재 상태: \(webtoon.status.rawValue)")
                 Text("평가: \(webtoon.rating.rawValue)")
                 TextEditor(text: $webtoon.review).frame(minHeight: 100)
+                Button("수정") {
+                    store.beginEditing(webtoon)
+                    selectedTab = 2
+                }
+                .frame(maxWidth: .infinity, alignment: .trailing)
             }
             .padding()
         }


### PR DESCRIPTION
## Summary
- remove custom back text in CategoryManagementView
- sort webtoons by rating order of 명작→수작→보통→졸작
- support editing existing webtoons via Add tab
- add Edit button to detail view to open Add tab prefilled
- rely on system background color for HomeView
- clarify AppLogo size guidance in README

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68835816844c832bba921c6d4165c763